### PR TITLE
zygote: Add /proc/ged to the FD whitelist

### DIFF
--- a/core/jni/fd_utils-inl.h
+++ b/core/jni/fd_utils-inl.h
@@ -57,7 +57,8 @@ static const char* kPathWhitelist[] = {
   "/dev/urandom",
   "/dev/ion",
   "@netlink@",
-  "/system/framework/org.cyanogenmod.platform-res.apk"
+  "/system/framework/org.cyanogenmod.platform-res.apk",
+  "/proc/ged"
 };
 
 static const char* kFdPath = "/proc/self/fd";


### PR DESCRIPTION
This is used by some platforms' gfx stack

Change-Id: Ife6e1b0df30fc23eff7fb6a16ff95c3e7b16a9c7